### PR TITLE
chore: adopt Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # ---- Build Stage ----
-FROM gradle:7.6.2-jdk11 AS build
+FROM gradle:8.10.1-jdk17 AS build
 WORKDIR /build
 COPY . .
 WORKDIR /build/server
-RUN ./gradlew clean bootJar
+RUN ./gradlew --no-daemon clean bootJar
 
 # ---- Production Stage ----
-FROM gcr.io/distroless/java11-debian11:nonroot
+FROM gcr.io/distroless/java17-debian11:nonroot
 WORKDIR /app
 COPY --from=build /build/server/build/libs/*.jar app.jar
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -37,6 +37,12 @@ apply plugin:"org.grails.grails-doc"
 // Fixing too long classpath in Windows development environment
 apply plugin: "ua.eshepelyuk.ManifestClasspath"
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 allprojects {
     repositories {
         mavenCentral()
@@ -101,15 +107,15 @@ dependencies {
     implementation 'org.grails.plugins:spring-security-rest:5.0.1'
     implementation 'commons-fileupload:commons-fileupload:1.5'
 
-    implementation 'commons-io:commons-io:2.13.0'
-    implementation 'org.apache.commons:commons-compress:1.23.0'
+    implementation 'commons-io:commons-io:2.15.1'
+    implementation 'org.apache.commons:commons-compress:1.26.2'
     implementation 'commons-validator:commons-validator:1.9.0'
-    implementation 'com.opencsv:opencsv:5.7.1'
+    implementation 'com.opencsv:opencsv:5.9'
     implementation 'com.github.ladutsko:isbn-core:1.5.3'
     implementation 'joda-time:joda-time:2.13.0'
     implementation 'org.opensearch:opensearch:2.19.1'
     implementation 'org.opensearch.client:opensearch-rest-high-level-client:2.19.1'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.2'
     implementation 'org.locationtech.spatial4j:spatial4j:0.8'
     implementation 'org.slf4j:log4j-over-slf4j:2.0.16'
     implementation 'org.apache.tika:tika-core:2.9.2'

--- a/utils/SyncClientLib/build.gradle
+++ b/utils/SyncClientLib/build.gradle
@@ -4,15 +4,21 @@ apply plugin:'application'
 mainClassName = 'org.gokb.client.DiffNotifier'
 defaultTasks 'clean', 'build', 'uberjar'
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
  
 repositories {
   mavenCentral()
 }
  
 dependencies {
-  implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.6'
-  testImplementation 'org.spockframework:spock-core:0.7-groovy-2.0'
-  implementation group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.5.0-RC2'
+  implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '3.0.21'
+  testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
+  implementation group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
   implementation group: 'berkeleydb', name: 'je', version: '3.2.76'
 }
 


### PR DESCRIPTION
## Summary
- configure Gradle builds to target Java 17
- bump some dependencies with known issues to newer releases
- rebuild Dockerfile on JDK 17 base images

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies - 403 Forbidden)*
- `../../server/gradlew --project-dir . test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe492b2f0832294205b0b7ceb1efd